### PR TITLE
Update for Visual Studio 2022 17.6.0 Preview 7.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ charset = utf-8
 indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
+spelling_exclusion_path = .\exclusion.dic
 
 [*.{h,cpp}]
 indent_size = 4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,6 +42,7 @@
 
       <!--
         Disable level All warnings that are not useful:
+        C4355: 'this': used in base member initializer list [triggered for STL header, even if all external warnings are disabled]
         C4514 = function' : unreferenced inline function has been removed [Just informational]
         C4571 = Informational: catch(...) semantics changed since Visual C++ 7.1; structured exceptions (SEH) are no longer caught [Just informational]
         C4623 = derived class' : default constructor was implicitly defined as deleted because a base class default constructor is inaccessible or deleted [Just informational]
@@ -55,6 +56,7 @@
         C4820 = bytes' bytes padding added after construct 'member_name' [Just informational]
         C4866 = compiler may not enforce left-to-right evaluation order [Just informational]
         C4868 = compiler may not enforce left-to-right evaluation order in braced initializer list [Just informational]
+        C5204:= class has virtual functions, but destructor is not virtual [triggered for STL header, even if all external warnings are disabled]
         C5026 = 'type': move constructor was implicitly defined as deleted [Just informational]
         C5027 = 'type': move assignment operator was implicitly defined as deleted  [Just informational]
         C5039 = 'function': pointer or reference to potentially throwing function passed to extern C function under -EHc. [Just informational]
@@ -63,7 +65,7 @@
         C5264 = '': 'const' variable is not used [Just informational]
       -->
       <DisableSpecificWarnings>4702</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(CHARLS_IMAGE_TEST_ALL_WARNINGS)'!=''">4514;4571;4623;4625;4626;4668;4702;4710;4711;4738;4820;4866;4868;5026;5027;5039;5045;5262;5264</DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(CHARLS_IMAGE_TEST_ALL_WARNINGS)'!=''">4355;4514;4571;4623;4625;4626;4668;4702;4710;4711;4738;4820;4866;4868;5204;5026;5027;5039;5045;5262;5264</DisableSpecificWarnings>
 
       <!--
         __cplusplus = Use the correct value for the __cplusplus macro

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple C++ console application that can verify the CharLS JPEG-LS codec by using
 from a directory filled with AnyMap images (.pgm, .ppm) by encoding them to JPEG-LS and back.
 
 This test application is not part of the main CharLS repository as it uses C\++20
-and CharLS is fixed on C++14 until the next major release.
+and CharLS is fixed on C++17 until the next major release.
 
 It can be build with MSVC++ with the .vcxproj file or with CMake for GCC, Clang and MSVC(C++17 mode).
 
@@ -12,3 +12,5 @@ Note 1: the AnyMap images are not part of this repository. These images can be d
 <http://imagecompression.info/test_images/>
 
 Note 2: use git clone --recurse-submodules to ensure that the CharLS sub module is also cloned.
+
+Note 3: Visual Studio 2022 17.6.0 Preview 7.0 or newer is needed to build for Windows.

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -1,0 +1,7 @@
+﻿bugprone
+﻿charls
+﻿vcxproj
+﻿anymap
+﻿anymap
+﻿charls
+﻿vcxproj

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,16 +187,9 @@ void triplet_to_planar(vector<byte>& buffer, const size_t width, const size_t he
 
 #ifdef __cpp_lib_format
     const int interleave_mode_width{color ? 6 : 4};
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4296) // '<': expression is always false [known problem in MSVC/STL, scheduled to be solved in VS 2022, 17.5]
-#endif
     puts(std::format(" Info: original size = {}, encoded size = {}, interleave mode = {:{}}, compression ratio = {:.2}:1, encode time = {:.4} ms, decode time = {:.4} ms",
                      reference_file.image_data().size(), encoded_size, interleave_mode_to_string(interleave_mode), interleave_mode_width, compression_ratio,
                      std::chrono::duration<double, std::milli>(encode_duration).count(), decode_duration.count()));
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 #else
     std::cout << " Info: original size = " << reference_file.image_data().size() << ", encoded size = " << encoded_size
               << ", interleave mode = " << interleave_mode_to_string(interleave_mode)
@@ -237,14 +230,7 @@ try
         if (const bool monochrome_anymap{entry.path().extension() == ".pgm"}; monochrome_anymap || entry.path().extension() == ".ppm")
         {
 #ifdef __cpp_lib_format
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4296) // '<': expression is always false [known problem in MSVC/STL, scheduled to be solved in VS 2022, 17.5]
-#endif
             puts(std::format("Checking file: {}", entry.path().string()));
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 #else
             std::cout << "Checking file: " << entry.path() << "\n";
 #endif
@@ -265,7 +251,7 @@ try
 }
 catch (const std::runtime_error& error)
 {
-    // By design only catch expected exceptions. Let other types escape to get a dumpfile that can be used for troubleshooting.
+    // By design only catch expected exceptions. Let other types escape to get a dump file that can be used for troubleshooting.
 #ifdef __cpp_lib_format
     puts(std::format("Unexpected failure: {}", error.what()));
 #else


### PR DESCRIPTION
VS 2022 17.5 cannot be used to build (it will cause an internal compiler error). Update the code to be allow building with 17.6.0 Preview 7.0.